### PR TITLE
Ignore P5 bugs in PENDING list

### DIFF
--- a/BTeam/RPC.pm
+++ b/BTeam/RPC.pm
@@ -51,7 +51,7 @@ sub pending_pri {
         'Extensions: MozProjectReview',
     );
 
-    my $bugs = $class->_bugs(priority => [qw( P1 P2 P3 P4 P5 )]);
+    my $bugs = $class->_bugs(priority => [qw( P1 P2 P3 P4 )]);
     BUG: foreach my $bug (@$bugs) {
         # skip assigned bugs
         next if $bug->{assigned_to} ne 'nobody@mozilla.org';


### PR DESCRIPTION
At the B-Team meeting today, we discussed removing P5's from this list. Under Emma's system, P5 is something that we never care about.
